### PR TITLE
Luckperms Integration

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -12,7 +12,15 @@
         "database": "bat",
         "user": "user",
         "password": "123456"
-      }
+      },
+      "luckPerms": {
+        "db": {
+          "host": "localhost",
+          "port": 3306,
+          "database": "lp",
+          "user": "user",
+          "password": "123456"
+        }
     },
     "mcServerStatus": {
       "servers": [

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -43,6 +43,7 @@ const config = convict({
           doc: 'The database port.',
           format: 'port',
           default: '3306',
+          env: 'LP_DB_PORT',
         },
         database: {
           doc: 'The database name.',
@@ -62,6 +63,41 @@ const config = convict({
           default: undefined,
           sensitive: true,
           env: 'BAT_DB_PASSWORD',
+        },
+      },
+    },
+    luckPerms: {
+      db: {
+        host: {
+          doc: 'The database host.',
+          format: String,
+          default: 'localhost',
+          env: 'LP_DB_HOST',
+        },
+        port: {
+          doc: 'The database port.',
+          format: 'port',
+          default: '3306',
+          env: 'LP_DB_PORT',
+        },
+        database: {
+          doc: 'The database name.',
+          format: String,
+          default: undefined,
+          env: 'LP_DB_NAME',
+        },
+        user: {
+          doc: 'The database user.',
+          format: String,
+          default: undefined,
+          env: 'LP_DB_USER',
+        },
+        password: {
+          doc: 'The database user password.',
+          format: String,
+          default: undefined,
+          sensitive: true,
+          env: 'LP_DB_PASSWORD',
         },
       },
     },

--- a/src/connectors/BungeeAdminToolsConnector/index.js
+++ b/src/connectors/BungeeAdminToolsConnector/index.js
@@ -25,7 +25,6 @@ Object.values(models).forEach((model) => model.associate(models));
 const bungeeAdminToolsConnector = {
   models,
   db,
-  Sequelize,
   testConnection() {
     return db.authenticate();
   },

--- a/src/connectors/LuckPermsConnector/index.js
+++ b/src/connectors/LuckPermsConnector/index.js
@@ -10,16 +10,13 @@ const db = new Sequelize(database, user, password, {
   dialect: 'mysql',
 });
 
-// TODO: Initialize models
-const models = {};
-
-// Establish associations between models
-Object.values(models).forEach((model) => model.associate(models));
+const models = {
+  playerPermissions: db.import(`${__dirname}/models/luckperms_user_permissions`),
+};
 
 const luckPermsConnector = {
   models,
   db,
-  Sequelize,
   testConnection() {
     return db.authenticate();
   },

--- a/src/connectors/LuckPermsConnector/index.js
+++ b/src/connectors/LuckPermsConnector/index.js
@@ -1,0 +1,28 @@
+const Sequelize = require('sequelize');
+const config = require('../../config');
+
+const {
+  host, database, user, password,
+} = config.get('connectors.luckPerms.db');
+
+const db = new Sequelize(database, user, password, {
+  host,
+  dialect: 'mysql',
+});
+
+// TODO: Initialize models
+const models = {};
+
+// Establish associations between models
+Object.values(models).forEach((model) => model.associate(models));
+
+const luckPermsConnector = {
+  models,
+  db,
+  Sequelize,
+  testConnection() {
+    return db.authenticate();
+  },
+};
+
+module.exports = { luckPermsConnector };

--- a/src/connectors/LuckPermsConnector/models/luckperms_actions.js
+++ b/src/connectors/LuckPermsConnector/models/luckperms_actions.js
@@ -1,0 +1,38 @@
+module.exports = (sequelize, DataTypes) => sequelize.define('luckperms_actions', {
+  id: {
+    type: DataTypes.INTEGER(11),
+    allowNull: false,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  time: {
+    type: DataTypes.BIGINT,
+    allowNull: false,
+  },
+  actor_uuid: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+  actor_name: {
+    type: DataTypes.STRING(100),
+    allowNull: true,
+  },
+  type: {
+    type: DataTypes.CHAR(1),
+    allowNull: false,
+  },
+  acted_uuid: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+  acted_name: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+  action: {
+    type: DataTypes.STRING(300),
+    allowNull: true,
+  },
+}, {
+  tableName: 'luckperms_actions',
+});

--- a/src/connectors/LuckPermsConnector/models/luckperms_group_permissions.js
+++ b/src/connectors/LuckPermsConnector/models/luckperms_group_permissions.js
@@ -1,0 +1,38 @@
+module.exports = (sequelize, DataTypes) => sequelize.define('luckperms_group_permissions', {
+  id: {
+    type: DataTypes.INTEGER(11),
+    allowNull: false,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  name: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+  permission: {
+    type: DataTypes.STRING(200),
+    allowNull: false,
+  },
+  value: {
+    type: DataTypes.INTEGER(1),
+    allowNull: false,
+  },
+  server: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+  world: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+  expiry: {
+    type: DataTypes.INTEGER(11),
+    allowNull: false,
+  },
+  contexts: {
+    type: DataTypes.STRING(200),
+    allowNull: false,
+  },
+}, {
+  tableName: 'luckperms_group_permissions',
+});

--- a/src/connectors/LuckPermsConnector/models/luckperms_groups.js
+++ b/src/connectors/LuckPermsConnector/models/luckperms_groups.js
@@ -1,0 +1,9 @@
+module.exports = (sequelize, DataTypes) => sequelize.define('luckperms_groups', {
+  name: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+    primaryKey: true,
+  },
+}, {
+  tableName: 'luckperms_groups',
+});

--- a/src/connectors/LuckPermsConnector/models/luckperms_players.js
+++ b/src/connectors/LuckPermsConnector/models/luckperms_players.js
@@ -1,0 +1,17 @@
+module.exports = (sequelize, DataTypes) => sequelize.define('luckperms_players', {
+  uuid: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+    primaryKey: true,
+  },
+  username: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+  },
+  primary_group: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+}, {
+  tableName: 'luckperms_players',
+});

--- a/src/connectors/LuckPermsConnector/models/luckperms_tracks.js
+++ b/src/connectors/LuckPermsConnector/models/luckperms_tracks.js
@@ -1,0 +1,13 @@
+module.exports = (sequelize, DataTypes) => sequelize.define('luckperms_tracks', {
+  name: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+    primaryKey: true,
+  },
+  groups: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
+}, {
+  tableName: 'luckperms_tracks',
+});

--- a/src/connectors/LuckPermsConnector/models/luckperms_user_permissions.js
+++ b/src/connectors/LuckPermsConnector/models/luckperms_user_permissions.js
@@ -35,4 +35,5 @@ module.exports = (sequelize, DataTypes) => sequelize.define('luckperms_user_perm
   },
 }, {
   tableName: 'luckperms_user_permissions',
+  timestamps: false,
 });

--- a/src/connectors/LuckPermsConnector/models/luckperms_user_permissions.js
+++ b/src/connectors/LuckPermsConnector/models/luckperms_user_permissions.js
@@ -1,0 +1,38 @@
+module.exports = (sequelize, DataTypes) => sequelize.define('luckperms_user_permissions', {
+  id: {
+    type: DataTypes.INTEGER(11),
+    allowNull: false,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  uuid: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+  permission: {
+    type: DataTypes.STRING(200),
+    allowNull: false,
+  },
+  value: {
+    type: DataTypes.INTEGER(1),
+    allowNull: false,
+  },
+  server: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+  world: {
+    type: DataTypes.STRING(36),
+    allowNull: false,
+  },
+  expiry: {
+    type: DataTypes.INTEGER(11),
+    allowNull: false,
+  },
+  contexts: {
+    type: DataTypes.STRING(200),
+    allowNull: false,
+  },
+}, {
+  tableName: 'luckperms_user_permissions',
+});

--- a/src/connectors/index.js
+++ b/src/connectors/index.js
@@ -1,7 +1,9 @@
 const { mcServerConnector } = require('./MCServerConnector');
 const { bungeeAdminToolsConnector } = require('./BungeeAdminToolsConnector');
+const { luckPermsConnector } = require('./LuckPermsConnector');
 
 module.exports = {
   mcServerConnector,
   bungeeAdminToolsConnector,
+  luckPermsConnector,
 };

--- a/src/models/Player.js
+++ b/src/models/Player.js
@@ -37,10 +37,11 @@ class Player {
     });
     // Group memberships are stored as permissions, e.g. Admins have the permission group.admin
     // Convert permission query results to group objects
+    // Filter out default group. It does not provide meaningful info.
     return result.map((entry) => ({
       id: entry.permission.split('.')[1],
       serverId: entry.server,
-    }));
+    })).filter((group) => group.id !== 'default');
   }
 
   static getByUUID(uuid) {

--- a/src/resolvers/playerResolvers.js
+++ b/src/resolvers/playerResolvers.js
@@ -23,6 +23,10 @@ const playerResolvers = {
       context.playerUUID = player.uuid;
       return {};
     },
+    groups: ((player) => Player.getGroups(player.uuid)),
+  },
+  PlayerGroup: {
+    server: ((group) => MCServer.getById(group.serverId)),
   },
 };
 

--- a/src/typeDefs/index.js
+++ b/src/typeDefs/index.js
@@ -1,7 +1,9 @@
 const { query } = require('./query');
-const { mcServerType, playerType, playerInfractionsType } = require('./types');
+const {
+  mcServerType, playerType, playerInfractionsType, playerGroupType,
+} = require('./types');
 
-const typeDefs = [query, mcServerType, playerType, playerInfractionsType];
+const typeDefs = [query, mcServerType, playerType, playerInfractionsType, playerGroupType];
 
 module.exports = {
   typeDefs,

--- a/src/typeDefs/types/index.js
+++ b/src/typeDefs/types/index.js
@@ -1,9 +1,11 @@
 const { mcServerType } = require('./mcServerType');
 const { playerType } = require('./playerType');
 const { playerInfractionsType } = require('./playerInfractionsType');
+const { playerGroupType } = require('./playerGroupType');
 
 module.exports = {
   mcServerType,
   playerType,
   playerInfractionsType,
+  playerGroupType,
 };

--- a/src/typeDefs/types/playerGroupType.js
+++ b/src/typeDefs/types/playerGroupType.js
@@ -1,0 +1,14 @@
+const { gql } = require('apollo-server');
+
+const playerGroupType = gql`    
+    type PlayerGroup {
+        "Unique identifier and displayname for this group."
+        id: ID!
+        "Server this group applies to."
+        server: MCServer
+    }
+`;
+
+module.exports = {
+  playerGroupType,
+};

--- a/src/typeDefs/types/playerType.js
+++ b/src/typeDefs/types/playerType.js
@@ -16,6 +16,8 @@ const playerType = gql`
         connectedTo: MCServer
         "Player infractions, such as bans."
         infractions: PlayerInfractions
+        "List of groups (ranks) this player belongs to."
+        groups: [PlayerGroup]
     }
 `;
 


### PR DESCRIPTION
Basic version which extends Player with an array of groups.
Groups have an ID and a server field.
This adds all Sequelize models for the LP database for future functionality. Only the permissions table model is imported for now.