### PR TITLE
Make the API able to take an array for name matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "graphql-subscriptions": "^2.0.0",
         "graphql-validation-complexity": "^0.3.0",
         "minecraft-protocol": "^1.16.0",
-        "mysql2": "^2.1.0",
+        "mysql2": "^3.10.2",
         "sequelize": "^6.29.0"
       },
       "devDependencies": {
@@ -605,11 +605,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/ansicolors": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
-    },
     "node_modules/apollo-datasource": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.2.tgz",
@@ -712,17 +707,6 @@
         "graphql": "^15.3.0 || ^16.0.0"
       }
     },
-    "node_modules/apollo-server-core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/apollo-server-core/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -734,11 +718,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/apollo-server-core/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/apollo-server-env": {
       "version": "4.2.1",
@@ -1045,22 +1024,13 @@
         "node": ">=6"
       }
     },
-    "node_modules/cardinal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
-      "dependencies": {
-        "ansicolors": "~0.3.2",
-        "redeyed": "~2.1.0"
-      },
-      "bin": {
-        "cdl": "bin/cdl.js"
-      }
-    },
     "node_modules/centra": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/centra/-/centra-2.4.2.tgz",
-      "integrity": "sha512-f1RaP0V1HqVNEXfLfjNBthB2yy3KnSGnPCnOPCFLUk9e/Z4rNJ8nBaJNnghflnp88mi1IT8mfmW+HlMS1/H+bg=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
+      "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.0",
@@ -1217,9 +1187,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1308,9 +1278,9 @@
       }
     },
     "node_modules/denque": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "engines": {
         "node": ">=0.10"
       }
@@ -1725,6 +1695,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1793,16 +1764,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -1909,6 +1880,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -2727,11 +2717,14 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/macaddress": {
@@ -2894,59 +2887,65 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/mysql2": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.1.0.tgz",
-      "integrity": "sha512-9kGVyi930rG2KaHrz3sHwtc6K+GY9d8wWk1XRSYxQiunvGcn4DwuZxOwmK11ftuhhwrYDwGx9Ta4VBwznJn36A==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.2.tgz",
+      "integrity": "sha512-KCXPEvAkO0RcHPr362O5N8tFY2fXvbjfkPvRY/wGumh4EOemo9Hm5FjQZqv/pCmrnuxGu5OxnSENG0gTXqKMgQ==",
       "dependencies": {
-        "cardinal": "^2.1.1",
-        "denque": "^1.4.1",
+        "denque": "^2.1.0",
         "generate-function": "^2.3.1",
-        "iconv-lite": "^0.5.0",
-        "long": "^4.0.0",
-        "lru-cache": "^5.1.1",
-        "named-placeholders": "^1.1.2",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru-cache": "^8.0.0",
+        "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.1"
+        "sqlstring": "^2.3.2"
       },
       "engines": {
         "node": ">= 8.0"
       }
     },
     "node_modules/mysql2/node_modules/iconv-lite": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mysql2/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/mysql2/node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
     "node_modules/named-placeholders": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
-      "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
       "dependencies": {
-        "lru-cache": "^4.1.3"
+        "lru-cache": "^7.14.1"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/named-placeholders/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
       }
-    },
-    "node_modules/named-placeholders/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3248,11 +3247,11 @@
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
     },
     "node_modules/phin": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/phin/-/phin-3.5.0.tgz",
-      "integrity": "sha512-BEJYqD07B5uBFPAzNpLuLh0LzHr4MDLe0Vc6gBYi+PSIL57VbiE/UvkCc86x24pKQn2X2Keg7HTJEDr8BrBCCg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
+      "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
       "dependencies": {
-        "centra": "^2.4.2"
+        "centra": "^2.7.0"
       },
       "engines": {
         "node": ">= 8"
@@ -3351,11 +3350,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -3438,14 +3432,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/redeyed": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
-      "dependencies": {
-        "esprima": "~4.0.0"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -3602,22 +3588,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -4436,9 +4406,9 @@
       }
     },
     "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs-parser": {
       "version": "20.2.9",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "graphql-subscriptions": "^2.0.0",
     "graphql-validation-complexity": "^0.3.0",
     "minecraft-protocol": "^1.16.0",
-    "mysql2": "^2.1.0",
+    "mysql2": "^3.10.2",
     "sequelize": "^6.29.0"
   },
   "devDependencies": {

--- a/src/models/Player.js
+++ b/src/models/Player.js
@@ -6,6 +6,14 @@ const { isNullUUID, fixUpUUID, stripUUID } = require('./util');
 const { Op } = Sequelize;
 
 class Player {
+  /**
+ * Returns a list of results from a players query in result and the number of total matches in totalCount.
+ * @param {number} limit - Max number of results to return.
+ * @param {number} offset - Number to offset the first index of results by, useful for pagination.
+ * @param {string} order - ASC or DESC, determines the order of players returned in result ordered by first joined date.
+ * @param {boolean} matchAll - If true; searchPlayerName's elements all should match lastSeenName to be returned. If false, any can match.
+ * @param {string[]} searchPlayerName - List of strings to use for filtering by lastSeenName 
+ */
   static async getPlayerList({
     limit, offset, order, matchAll, searchPlayerName,
   }) {
@@ -16,25 +24,22 @@ class Player {
     };
 
     if (searchPlayerName) {
+      const nameMatchElements = searchPlayerName.map((nameElement) => ({
+        lastSeenName: {
+          [Op.like]: nameElement,
+        },
+      }));
 
-        var nameMatchElements = searchPlayerName.map(nameElement => {
-            return {
-                lastSeenName: { 
-                    [Op.like] : nameElement,
-                }
-            }
-        })
-        
-        // And forces all to match, Or allows any to match
-        if(matchAll) {
-            options.where = {
-                [Op.and] : nameMatchElements
-              };
-        } else {
-            options.where = {
-                [Op.or] : nameMatchElements
-            };
-        }
+      // And forces all to match, Or allows any to match
+      if (matchAll) {
+        options.where = {
+          [Op.and]: nameMatchElements,
+        };
+      } else {
+        options.where = {
+          [Op.or]: nameMatchElements,
+        };
+      }
     }
     const playerQuery = bungeeAdminToolsConnector.models.player.findAll(options)
       // Fix invalid UUIDS without dashes

--- a/src/models/Player.js
+++ b/src/models/Player.js
@@ -6,13 +6,13 @@ const { isNullUUID, fixUpUUID, stripUUID } = require('./util');
 const { Op } = Sequelize;
 
 class Player {
-  /**
+ /**
  * Returns a list of results from a players query in result and the number of total matches in totalCount.
  * @param {number} limit - Max number of results to return.
  * @param {number} offset - Number to offset the first index of results by, useful for pagination.
  * @param {string} order - ASC or DESC, determines the order of players returned in result ordered by first joined date.
- * @param {boolean} matchAll - If true; searchPlayerName's elements all should match lastSeenName to be returned. If false, any can match.
- * @param {string[]} searchPlayerName - List of strings to use for filtering by lastSeenName 
+ * @param {boolean} [matchAll=true] - If true; searchPlayerName's elements all should match lastSeenName to be returned. If false, any can match.
+ * @param {string[]} [searchPlayerName=[]] - List of strings to use for filtering by lastSeenName 
  */
   static async getPlayerList({
     limit, offset, order, matchAll, searchPlayerName,

--- a/src/resolvers/playerResolvers.js
+++ b/src/resolvers/playerResolvers.js
@@ -5,14 +5,14 @@ const MAX_PLAYER_QUERY_COUNT = 100;
 const playerResolvers = {
   Query: {
     players: ((_, {
-      limit, offset, order, searchPlayerName,
+      limit, offset, order, matchAll, searchPlayerName,
     }) => {
       let queryLimit = limit;
       if (queryLimit > MAX_PLAYER_QUERY_COUNT) {
         queryLimit = MAX_PLAYER_QUERY_COUNT;
       }
       return Player.getPlayerList({
-        limit: queryLimit, offset, order, searchPlayerName,
+        limit: queryLimit, offset, order, matchAll, searchPlayerName,
       });
     }),
     player: (_, { uuid }) => Player.getByUUID(uuid),

--- a/src/typeDefs/query.js
+++ b/src/typeDefs/query.js
@@ -21,8 +21,10 @@ const query = gql`
             offset: Int = 0,
             "Whether to sort ascending or descending by player first join date."
             order: ListOrder = DESC,
-            "Filter results by last seen player name. Supports SQL LIKE patterns."
-            searchPlayerName: String
+            "If true, searchPlayerName must have all elements match a username, if false any can match."
+            matchAll: Boolean = true,
+            "Filter results by last seen player name. Supports SQL LIKE patterns. Matching parameters defined by matchAll"
+            searchPlayerName: [String]
         ): PlayerSearchResult!
         player(
             "The unique identifier of the player as defined by Minecraft. Must be a valid UUIDv4 with dashes."


### PR DESCRIPTION
Introduces no breaking changes and old queries behave exactly the same, but if you pass an array into `searchPlayerName` in a `players` query, it will now do a bit more matching work. 

Added a new parameter for `players` queries, `matchAll` to go along with allowing for arrays into `searchPlayerName`. If `matchAll` is false, any of the strings inside `searchPlayerName` can match a name for it to be returned, otherwise they must all match.